### PR TITLE
Made ThrowableProxy templated on the throwable type.

### DIFF
--- a/core/fluentasserts/core/callable.d
+++ b/core/fluentasserts/core/callable.d
@@ -5,7 +5,7 @@ import std.string;
 import std.datetime;
 import std.conv;
 
-struct ThrowableProxy {
+struct ThrowableProxy(T : Throwable) {
   import fluentasserts.core.results;
 
   private const {
@@ -19,10 +19,10 @@ struct ThrowableProxy {
     Message[] messages;
     string reason;
     bool check;
-    Throwable t;
+    T t;
   }
 
-  this(Throwable t, bool expectedValue, bool rightType, Message[] messages, const string file, size_t line) {
+  this(T t, bool expectedValue, bool rightType, Message[] messages, const string file, size_t line) {
     this.expectedValue = expectedValue;
     this._file = file;
     this._line = line;
@@ -181,7 +181,7 @@ struct ShouldCallable(T) {
       rightType = false;
     }
 
-    return ThrowableProxy(t, expectedValue, rightType, messages, file, line);
+    return ThrowableProxy!T(t, expectedValue, rightType, messages, file, line);
   }
 }
 

--- a/core/fluentasserts/core/callable.d
+++ b/core/fluentasserts/core/callable.d
@@ -28,7 +28,7 @@ struct ThrowableProxy(T : Throwable) {
     this._file = file;
     this._line = line;
     this.thrown = thrown;
-    if (rightType) this.thrownTyped = cast(T)(thrownTyped);
+    if (rightType) this.thrownTyped = cast(T)thrown;
     this.messages = messages;
     this.check = true;
     this.rightType = rightType;
@@ -227,6 +227,28 @@ unittest
   }
 
   hasException.should.equal(true).because("we want to catch a CustomException not an Exception");
+}
+
+/// Should be able to retrieve a typed version of a custom exception
+unittest
+{
+  class CustomException : Exception {
+    int data;
+    this(int data, string msg, string fileName = "", size_t line = 0, Throwable next = null) {
+      super(msg, fileName, line, next);
+
+      this.data = data;
+    }
+  }
+
+  auto thrown = ({
+    throw new CustomException(2, "test");
+  }).should.throwException!CustomException.original;
+
+  thrown.should.not.beNull;
+  thrown.should.instanceOf!CustomException;
+  thrown.msg.should.equal("test");
+  thrown.data.should.equal(2);
 }
 
 /// Should print a nice message for exception message asserts


### PR DESCRIPTION
This would allow for the following (with vibe.d):

```dlang
auto thrown = ({
    ...
}).should.throwException!HTTPStatusException.original;

thrown.status.should.equal(HTTPStatus.notFound);
```