### PR TITLE
Fix deprecation warnings

### DIFF
--- a/source/fluentasserts/core/basetype.d
+++ b/source/fluentasserts/core/basetype.d
@@ -20,9 +20,9 @@ struct ShouldBaseType(T) {
   mixin ShouldCommons;
   mixin ShouldThrowableCommons;
 
-  alias above = this.greaterThan;
-  alias below = this.lessThan;
-  alias within = this.between;
+  alias above = typeof(this).greaterThan;
+  alias below = typeof(this).lessThan;
+  alias within = typeof(this).between;
 
   auto equal(const T someValue, const string file = __FILE__, const size_t line = __LINE__) {
     validateException;


### PR DESCRIPTION
Fixes this:
```
source/fluentasserts/core/basetype.d(23,17): Deprecation: Using this as a type is deprecated. Use typeof(this) instead
source/fluentasserts/core/basetype.d(24,17): Deprecation: Using this as a type is deprecated. Use typeof(this) instead
source/fluentasserts/core/basetype.d(25,18): Deprecation: Using this as a type is deprecated. Use typeof(this) instead
<repeated over and over again>
```