### PR TITLE
Fix Compilation Errors with DMD v2.104.0 onward

### DIFF
--- a/source/fluentasserts/core/message.d
+++ b/source/fluentasserts/core/message.d
@@ -181,15 +181,15 @@ void addDiff(ref EvaluationResult result, string actual, string expected) nothro
 
     foreach(diff; diffResult) {
       if(diff.operation == Operation.EQUAL) {
-        result.add(Message(Message.Type.info, diff.text));
+        result.add(Message(Message.Type.info, diff.text.to!string));
       }
 
       if(diff.operation == Operation.INSERT) {
-        result.add(Message(Message.Type.insert, diff.text));
+        result.add(Message(Message.Type.insert, diff.text.to!string));
       }
 
       if(diff.operation == Operation.DELETE) {
-        result.add(Message(Message.Type.delete_, diff.text));
+        result.add(Message(Message.Type.delete_, diff.text.to!string));
       }
     }
   } catch(Exception e) {

--- a/source/fluentasserts/core/results.d
+++ b/source/fluentasserts/core/results.d
@@ -300,11 +300,11 @@ class DiffResult : IResult {
   private string getResult(const Diff d) {
     final switch(d.operation) {
         case Operation.DELETE:
-          return ResultGlyphs.diffBegin ~ ResultGlyphs.diffDelete ~ d.text ~ ResultGlyphs.diffEnd;
+          return ResultGlyphs.diffBegin ~ ResultGlyphs.diffDelete ~ d.text.to!string ~ ResultGlyphs.diffEnd;
         case Operation.INSERT:
-          return ResultGlyphs.diffBegin ~ ResultGlyphs.diffInsert ~ d.text ~ ResultGlyphs.diffEnd;
+          return ResultGlyphs.diffBegin ~ ResultGlyphs.diffInsert ~ d.text.to!string ~ ResultGlyphs.diffEnd;
         case Operation.EQUAL:
-          return d.text;
+          return d.text.to!string;
     }
   }
 
@@ -318,15 +318,15 @@ class DiffResult : IResult {
 
     foreach(diff; result) {
       if(diff.operation == Operation.EQUAL) {
-        printer.primary(diff.text);
+        printer.primary(diff.text.to!string);
       }
 
       if(diff.operation == Operation.INSERT) {
-        printer.successReverse(diff.text);
+        printer.successReverse(diff.text.to!string);
       }
 
       if(diff.operation == Operation.DELETE) {
-        printer.dangerReverse(diff.text);
+        printer.dangerReverse(diff.text.to!string);
       }
     }
 


### PR DESCRIPTION
Avoid implicitly converting from dstring to string, which appears to be no longer supported from dmd-2.104.0 onwards.

Fixes #102.